### PR TITLE
Include subfolders and various options

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,27 +71,27 @@ creation of the executable, e.g. for a build process.
 All options have backwards compatibility to previous releases of Node-EnigmaVirtualBox
 that did not have these options yet.
 
-**--enableSubfolder=(true|false)**
+**--enableSubfolder=(true|false)**  
 Defaults to *false*. If set to true, the folder structure of the files is kept.
 If set to false or omitted, all files will end up in the virtual root directory.
 
-**--shareVirtualSystem=(true|false)**
+**--shareVirtualSystem=(true|false)**  
 Defaults to *true*. Maps to the Enigma Virtual Box GUI option "Share virtual system
 to child processes".
 
-**--mapExecutableWithTemporaryFile=(true|false)**
+**--mapExecutableWithTemporaryFile=(true|false)**  
 Defaults to *false*. Maps to the Enigma Virtual Box GUI option "Map executable files
 using temporary files".
 
-**--allowRunningOfVirtualExeFiles=(true|false)**
+**--allowRunningOfVirtualExeFiles=(true|false)**  
 Defaults to *true*. Maps to the Enigma Virtual Box GUI option "Allow running of virtual
 executable files".
 
-**--compressFiles=(true|false)**
+**--compressFiles=(true|false)**  
 Defaults to *true*. If set to false, files will not be compressed, resulting in a
 larger executable file.
 
-**--deleteExtractedOnExit=(true|false)**
+**--deleteExtractedOnExit=(true|false)**  
 Defaults to *true*. If set to false, extracted files will remain in their temporary
 directory. Mainly used for debugging purposes.
 
@@ -122,16 +122,12 @@ Examples with options
 ```js
 var evb = require("enigmavirtualbox");
 evb.gen("--compressFiles=false", "--enableSubfolders=true", "app.evp", "app-bundled.exe", "app.exe", "app.dat", "subfolder\file.dat").then(...);
-evb.gui("app.evp").then(...);
 evb.cli("app.evp").then(...);
 ```
 
 ```sh
-# run the generator to create a new standard configuration with
+# run the generator to create a new configuration with subfolders enabled and no compression
 $ enigmavirtualbox gen --compressFiles=false --enableSubfolders=true app.evp app-bundled.exe app.exe app.dat subfolder\file.dat
-
-# run the GUI to create/modify a new/existing configuration
-$ enigmavirtualbox gui [app.evp]
 
 # run the CLI to pack application according to configuration
 $ enigmavirtualbox cli app.evp

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Examples with options
 
 ```js
 var evb = require("enigmavirtualbox");
-evb.gen("--compressFiles=false", "--enableSubfolders=true", "app.evp", "app-bundled.exe", "app.exe", "app.dat", "subfolder\file.dat").then(...);
+evb.gen("--compressFiles=false", "--enableSubfolders=true", "app.evp", "app-bundled.exe", "app.exe", "app.dat", "subfolder\\file.dat").then(...);
 evb.cli("app.evp").then(...);
 ```
 

--- a/README.md
+++ b/README.md
@@ -48,16 +48,52 @@ Usage
 
 ```js
 var evb = require("enigmavirtualbox");
-evb.gen(<arg>[, <arg>, ...]).then(...);
+evb.gen([<option>, ...], <arg>[, <arg>, ...]).then(...);
 evb.gui(<arg>[, <arg>, ...]).then(...);   // requires Windows run-time platform
 evb.cli(<arg>[, <arg>, ...]).then(...);   // requires Windows run-time platform
 ```
 
 ```sh
-$ enigmavirtualbox gen <arg> [<arg> ...]
+$ enigmavirtualbox gen [<option>, ...] <arg> [<arg> ...]
 $ enigmavirtualbox gui <arg> [<arg> ...]  # requires Windows run-time platform
 $ enigmavirtualbox cli <arg> [<arg> ...]  # requires Windows run-time platform
 ```
+
+Options
+-------
+
+There are some options available for the generation of the *.evb file.
+When used, they have to be passed as first arguments to the "gen" call.
+
+These options are useful to bypass the call of the GUI and to fully automate the
+creation of the executable, e.g. for a build process.
+
+All options have backwards compatibility to previous releases of Node-EnigmaVirtualBox
+that did not have these options yet.
+
+*--enableSubfolder=(true|false)*
+Defaults to *false*. If set to true, the folder structure of the files is kept.
+If set to false or omitted, all files will end up in the virtual root directory.
+
+*--shareVirtualSystem=(true|false)*
+Defaults to *true*. Maps to the Enigma Virtual Box GUI option "Share virtual system
+to child processes".
+
+*--mapExecutableWithTemporaryFile=(true|false)*
+Defaults to *false*. Maps to the Enigma Virtual Box GUI option "Map executable files
+using temporary files".
+
+*--allowRunningOfVirtualExeFiles=(true|false)*
+Defaults to *true*. Maps to the Enigma Virtual Box GUI option "Allow running of virtual
+executable files".
+
+*--compressFiles=(true|false)*
+Defaults to *true*. If set to false, files will not be compressed, resulting in a
+larger executable file.
+
+*--deleteExtractedOnExit=(true|false)*
+Defaults to *true*. If set to false, extracted files will remain in their temporary
+directory. Mainly used for debugging purposes.
 
 Examples
 --------
@@ -76,9 +112,32 @@ $ enigmavirtualbox gen app.evp app-bundled.exe app.exe app.dat
 # run the GUI to create/modify a new/existing configuration
 $ enigmavirtualbox gui [app.evp]
 
-# runt the CLI to pack application according to configuration
+# run the CLI to pack application according to configuration
 $ enigmavirtualbox cli app.evp
 ```
+
+Examples with options
+---------------------
+
+```js
+var evb = require("enigmavirtualbox");
+evb.gen("--compressFiles=false", "--enableSubfolders=true", "app.evp", "app-bundled.exe", "app.exe", "app.dat", "subfolder\file.dat").then(...);
+evb.gui("app.evp").then(...);
+evb.cli("app.evp").then(...);
+```
+
+```sh
+# run the generator to create a new standard configuration with
+$ enigmavirtualbox gen --compressFiles=false --enableSubfolders=true app.evp app-bundled.exe app.exe app.dat subfolder\file.dat
+
+# run the GUI to create/modify a new/existing configuration
+$ enigmavirtualbox gui [app.evp]
+
+# run the CLI to pack application according to configuration
+$ enigmavirtualbox cli app.evp
+```
+
+
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -71,27 +71,27 @@ creation of the executable, e.g. for a build process.
 All options have backwards compatibility to previous releases of Node-EnigmaVirtualBox
 that did not have these options yet.
 
-*--enableSubfolder=(true|false)*
+**--enableSubfolder=(true|false)**
 Defaults to *false*. If set to true, the folder structure of the files is kept.
 If set to false or omitted, all files will end up in the virtual root directory.
 
-*--shareVirtualSystem=(true|false)*
+**--shareVirtualSystem=(true|false)**
 Defaults to *true*. Maps to the Enigma Virtual Box GUI option "Share virtual system
 to child processes".
 
-*--mapExecutableWithTemporaryFile=(true|false)*
+**--mapExecutableWithTemporaryFile=(true|false)**
 Defaults to *false*. Maps to the Enigma Virtual Box GUI option "Map executable files
 using temporary files".
 
-*--allowRunningOfVirtualExeFiles=(true|false)*
+**--allowRunningOfVirtualExeFiles=(true|false)**
 Defaults to *true*. Maps to the Enigma Virtual Box GUI option "Allow running of virtual
 executable files".
 
-*--compressFiles=(true|false)*
+**--compressFiles=(true|false)**
 Defaults to *true*. If set to false, files will not be compressed, resulting in a
 larger executable file.
 
-*--deleteExtractedOnExit=(true|false)*
+**--deleteExtractedOnExit=(true|false)**
 Defaults to *true*. If set to false, extracted files will remain in their temporary
 directory. Mainly used for debugging purposes.
 

--- a/enigmavirtualbox-api.js
+++ b/enigmavirtualbox-api.js
@@ -93,11 +93,58 @@ module.exports = {
     gen: function () {
         var args = Array.prototype.slice.call(arguments, 0);
         return new promise(function (resolve, reject) {
+
+            // Default settings for optional flags (compatible with previous releases of node-enigmavirtualbox):
+            var enableSubfolders = false; // if set to true, folder structure is inserted into enigma project
+            var compressFiles = true;
+            var deleteExtractedOnExit = true;
+            var shareVirtualSystem = true; // Setting for <options> section.
+            var mapExecutableWithTemporaryFile = false; // Setting for <options> section.
+            var allowRunningOfVirtualExeFiles = true; // Setting for <options> section.
+
             try {
+                // process options:
+                do {
+                    var arg = args.shift();
+                    switch (arg.toLowerCase()) {
+                        case '--enablesubfolders':
+                        case '--enablesubfolders=1':
+                        case '--enablesubfolders=true':
+                            enableSubfolders = true;
+                            break;
+                        case '--sharevirtualsystem=0':
+                        case '--sharevirtualsystem=false':
+                            shareVirtualSystem = false;
+                            break;
+                        case '--mapexecutablewithtemporaryfile':
+                        case '--mapexecutablewithtemporaryfile=1':
+                        case '--mapexecutablewithtemporaryfile=true':
+                            mapExecutableWithTemporaryFile = true;
+                            break;
+                        case '--allowrunningofvirtualexefiles=0':
+                        case '--allowrunningofvirtualexefiles=false':
+                            allowRunningOfVirtualExeFiles = false;
+                            break;
+                        case '--compressfiles=0':
+                        case '--compressfiles=false':
+                            compressFiles = false;
+                            break;
+                        case '--deleteextractedonexit=0':
+                        case '--deleteextractedonexit=false':
+                            deleteExtractedOnExit = false;
+                            break;
+                    }
+                } while (arg.substring(0, 2) == '--');
+                if (arg != undefined)
+                    args.unshift(arg);
+
                 if (args.length < 3)
                     throw new Error("invalid number of arguments");
                 var output = args.shift();
-                var xml = require("./enigmavirtualbox-gen.js")(args);
+                var xml = require("./enigmavirtualbox-gen.js")(
+                    args, enableSubfolders, compressFiles, deleteExtractedOnExit, shareVirtualSystem,
+                    mapExecutableWithTemporaryFile, allowRunningOfVirtualExeFiles
+                );
                 xml = iconv.encode(xml, "utf16le");
                 fs.writeFileSync(output, xml, {});
             }

--- a/enigmavirtualbox-gen.js
+++ b/enigmavirtualbox-gen.js
@@ -36,6 +36,10 @@ var path = require("path");
 var pathResolve = function (filepath, hasToExist) {
     if (hasToExist && !fs.existsSync(filepath))
         throw new Error("path \"" + filepath + "\" not existing");
+    var isSubFolder = filepath.indexOf("\\") > 0;
+    if(isSubFolder) {
+         return filepath;
+    }
     filepath = ".\\" + path.relative(process.cwd(), filepath);
     return filepath;
 };

--- a/enigmavirtualbox-gen.js
+++ b/enigmavirtualbox-gen.js
@@ -40,10 +40,119 @@ var pathResolve = function (filepath, hasToExist) {
     return filepath;
 };
 
+/**
+ * Generates a tree structure of the fileList array, e.g.:
+ *
+ * tree = {
+ *    "files": ["index.html"],
+ *    "folders": {
+ *        "myFolder": {
+ *            "files": ["foo.bak", "far.baz"],
+ *            "folders": {}
+ *        },
+ *        "myOtherFolder": {
+ *            "files": [],
+ *            "folders": {
+ *                "nestedFolder": {
+ *                    "files": ["foo.bar"],
+ *                    "folders": {}
+ *                }
+ *            }
+ *        }
+ *    }
+ *};
+ *
+ * @param fileList
+ * @param keepFolders
+ */
+var fileListToTree = function (fileList, keepFolders) {
+    var addRecursively = function(obj, items, fullPath) {
+        if (items.length == 1) {
+            // file in root:
+            var file = {};
+            file["name"] = items[0];
+            file["path"] = path.resolve(fullPath); // absolute path on filesystem is needed.
+            obj.files.push(file);
+        } else {
+            var firstItem = items.shift();
+            if (firstItem == '.' || firstItem == '..') {
+                addRecursively(obj, items, fullPath);
+                return;
+            }
+            if (!obj.folders.hasOwnProperty(firstItem)) {
+                obj.folders[firstItem] = {"files":[], "folders":{}};
+            }
+            var currentLeaf = obj.folders[firstItem];
+            addRecursively(currentLeaf, items, fullPath);
+        }
+
+    };
+    var tree = {"files":[],  "folders": {}};
+    var split, fullPath, lastItem;
+    for (var i = 0; i < fileList.length; i++) {
+        split = fileList[i].split("\\");
+        fullPath = fileList[i];
+        if (keepFolders) {
+            addRecursively(tree, split, fullPath);
+        } else {
+            tree.files.push(
+                {
+                    "name": split[split.length-1],
+                    "path": fullPath
+                }
+            );
+        }
+    }
+    return tree;
+};
+
+var getXmlFolderRecursively = function(folderName, currentLeaf, indentLevel) {
+    var indent = new Array(indentLevel + 1).join(' ');
+    var snippet = "" +
+        indent + "<File>\n" +
+        indent + "    <Type>3</Type>\n" +
+        indent + "    <Name>" + folderName + "</Name>\n" +
+        indent + "    <Files>\n";
+
+    if (Object.keys(currentLeaf.folders).length) {
+        for (var folder in currentLeaf.folders) {
+            if (currentLeaf.folders.hasOwnProperty(folder)) {
+                snippet += getXmlFolderRecursively(folder, currentLeaf.folders[folder], indentLevel + 8)
+            }
+        }
+    }
+    for (var i = 0; i<currentLeaf.files.length; i++ ) {
+        snippet += "" +
+            indent + "        <File>\n" +
+            indent + "            <Type>2</Type>\n" +
+            indent + "            <Name>" + currentLeaf.files[i].name + "</Name>\n" +
+            indent + "            <File>" + currentLeaf.files[i].path + "</File>\n" +
+            indent + "            <ActiveX>false</ActiveX>\n" +
+            indent + "            <ActiveXInstall>false</ActiveXInstall>\n" +
+            indent + "            <Action>0</Action>\n" +
+            indent + "            <OverwriteDateTime>false</OverwriteDateTime>\n" +
+            indent + "            <OverwriteAttributes>false</OverwriteAttributes>\n" +
+            indent + "            <PassCommandLine>false</PassCommandLine>\n" +
+            indent + "        </File>\n";
+    }
+
+    snippet += "" +
+        indent + "    </Files>\n" +
+        indent + "</File>\n";
+
+    return snippet;
+};
+
 /*  the exported API  */
-module.exports = function (args) {
+module.exports = function (args, enableSubfolders, compressFiles, deleteExtractedOnExit, shareVirtualSystem, mapExecutableWithTemporaryFile, allowRunningOfVirtualExeFiles) {
     var exe_out = pathResolve(args.shift(), false);
     var exe_in  = pathResolve(args.shift(), true);
+    var fileList = [];
+    for (var i = 0; i < args.length; i++) {
+        var file = pathResolve(args[i], true);
+        fileList.push(file);
+    }
+    var tree = fileListToTree(fileList, enableSubfolders);
     var xml = "" +
         "<?xml encoding=\"utf-16\"?>\n" +
         "<>\n" +
@@ -51,32 +160,13 @@ module.exports = function (args) {
         "    <OutputFile>" + exe_out + "</OutputFile>\n" +
         "    <Files>\n" +
         "        <Enabled>true</Enabled>\n" +
-        "        <DeleteExtractedOnExit>true</DeleteExtractedOnExit>\n" +
-        "        <CompressFiles>true</CompressFiles>\n" +
-        "        <Files>\n" +
-        "            <File>\n" +
-        "                <Type>3</Type>\n" +
-        "                <Name>%DEFAULT FOLDER%</Name>\n" +
-        "                <Files>\n";
-    for (var i = 0; i < args.length; i++) {
-        var file = pathResolve(args[i], true);
-        var name = path.basename(file);
-        xml += "" +
-        "                    <File>\n" +
-        "                        <Type>2</Type>\n" +
-        "                        <Name>" + name + "</Name>\n" +
-        "                        <File>" + file + "</File>\n" +
-        "                        <ActiveX>false</ActiveX>\n" +
-        "                        <ActiveXInstall>false</ActiveXInstall>\n" +
-        "                        <Action>0</Action>\n" +
-        "                        <OverwriteDateTime>false</OverwriteDateTime>\n" +
-        "                        <OverwriteAttributes>false</OverwriteAttributes>\n" +
-        "                        <PassCommandLine>false</PassCommandLine>\n" +
-        "                    </File>\n";
-    }
+        "        <DeleteExtractedOnExit>" + (deleteExtractedOnExit ? "true" : "false") + "</DeleteExtractedOnExit>\n" +
+        "        <CompressFiles>" + (compressFiles ? "true" : "false") + "</CompressFiles>\n" +
+        "        <Files>\n";
+
+    xml += getXmlFolderRecursively("%DEFAULT FOLDER%", tree, 12);
+
     xml +=
-        "                </Files>\n" +
-        "            </File>\n" +
         "        </Files>\n" +
         "    </Files>\n" +
         "    <Registries>\n" +
@@ -128,9 +218,9 @@ module.exports = function (args) {
         "        <Enabled>false</Enabled>\n" +
         "    </Packaging>\n" +
         "    <Options>\n" +
-        "        <ShareVirtualSystem>true</ShareVirtualSystem>\n" +
-        "        <MapExecutableWithTemporaryFile>false</MapExecutableWithTemporaryFile>\n" +
-        "        <AllowRunningOfVirtualExeFiles>true</AllowRunningOfVirtualExeFiles>\n" +
+        "        <ShareVirtualSystem>" + (shareVirtualSystem ? "true" : "false") + "</ShareVirtualSystem>\n" +
+        "        <MapExecutableWithTemporaryFile>" + (mapExecutableWithTemporaryFile ? "true" : "false") + "</MapExecutableWithTemporaryFile>\n" +
+        "        <AllowRunningOfVirtualExeFiles>" + (allowRunningOfVirtualExeFiles ? "true" : "false") + "</AllowRunningOfVirtualExeFiles>\n" +
         "    </Options>\n" +
         "</>\n";
     return xml.replace(/\s{4}/g, "\t");


### PR DESCRIPTION
In this fork I contribute some enhancements to Node-VirtualBox.

**Subfolders**  
Optionally, subfolders may now be included in the generated .evb file. The tree structure remains unchanged.

**Various options**  
I added a variety of options to the "gen" command. These map to the Enigma Virtual Box GUI settings and enable users to bypass the "gui" call, which comes useful e.g. when setting up fully automated build processes.

Please view the readme.md for all details, and feel free to pull my contribution if suitable.
